### PR TITLE
Bump pyyaml and specify explicit FullLoader for yaml

### DIFF
--- a/bellybutton/parsing.py
+++ b/bellybutton/parsing.py
@@ -173,7 +173,7 @@ def parse_rule(rule_name, rule_values, default_settings=None):
 
 def load_config(fileobj):
     """Load bellybutton config file, returning a list of rules."""
-    loaded = yaml.load(fileobj)
+    loaded = yaml.load(fileobj, Loader = yaml.FullLoader)
     default_settings = loaded.get('default_settings')
     rules = [
         parse_rule(rule_name, rule_values, default_settings)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='bellybutton',
     packages=['bellybutton'],
     platforms='any',
-    version='0.2.5',
+    version='0.3.0',
     description='Custom Python linting through AST expressions.',
     author='H. Chase Stevens',
     author_email='chase@chasestevens.com',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     install_requires=[
         'astpath[xpath]==0.6.1',
-        'pyyaml>=3.12,<4.0',
+        'pyyaml>=4.0,<6.0',
         'lxml>=4.1.1',
     ],
     tests_require=['pytest>=3.1.2', 'future>=0.16.0'],


### PR DESCRIPTION
Version for pyyaml has been restricted because it has started to require
an explicit loader for loading yaml files (see #20).
By applying this commit, we can now remove the restriction,
since we explicitly specify the loader.

We had to bump the lower bound for pyyaml to `>=4.0` because `3.x` versions did not have a `FullLoader`, which is required for this to work properly.