### PR TITLE
Use re.Pattern for python 3.8 compatibility and fallback to re._pattern_type in older versions.

### DIFF
--- a/bellybutton/linting.py
+++ b/bellybutton/linting.py
@@ -9,6 +9,11 @@ from operator import attrgetter
 from astpath import find_in_ast, file_contents_to_xml_ast
 from lxml.etree import XPath
 
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type
+
 LintingResult = namedtuple('LintingResult', 'rule filepath succeeded lineno')
 
 
@@ -59,7 +64,7 @@ def lint_file(filepath, file_contents, rules):
                 rule.expr.path,
                 return_lines=True
             ))
-        elif isinstance(rule.expr, re._pattern_type):
+        elif isinstance(rule.expr, pattern_type):
             matching_lines = {
                 file_contents[:match.start()].count('\n') + 1  # TODO - slow
                 for match in re.finditer(rule.expr, file_contents)

--- a/tests/unit/test_parsing.py
+++ b/tests/unit/test_parsing.py
@@ -10,13 +10,17 @@ from lxml.etree import XPath, XPathSyntaxError
 from bellybutton.exceptions import InvalidNode
 from bellybutton.parsing import Settings, parse_rule, Rule
 
+try:
+    from re import Pattern as pattern_type
+except ImportError:
+    from re import _pattern_type as pattern_type
 
 @pytest.mark.parametrize('expression,expected_type', (
     ('!xpath //*', XPath),
     ('//*', XPath),
     pytest.mark.xfail(('//[]', XPath), raises=InvalidNode),
-    ('!regex .*', re._pattern_type),
-    pytest.mark.xfail(('!regex "*"', re._pattern_type), raises=InvalidNode),
+    ('!regex .*', pattern_type),
+    pytest.mark.xfail(('!regex "*"', pattern_type), raises=InvalidNode),
     ('!settings {included: [], excluded: [], allow_ignore: yes}', Settings),
     pytest.mark.xfail(('!settings {}', Settings), raises=InvalidNode)
 ))


### PR DESCRIPTION
Fixes #28 