### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: bellybutton
+  name: bellybutton
+  description: 'bellybutton is a customizable, easy-to-configure linting engine for Python.'
+  entry: bellybutton lint
+  pass_filenames: False
+  language: python
+  types: [python]
+


### PR DESCRIPTION
First of all, great work with bellybutton, thanks for that!

We are using [pre-commit](https://pre-commit.com/) and I was wondering if we could add bellybutton as a hook as well. We can use our own fork, but other people might want to use it like this too, so here it is. The addition of the `.pre-commit-hooks.yaml` file allows this repo to be used with pre-commit. It will simply run `bellybutton lint` for you in your repository and you can add args if you like into your own pre-commit config.

It can be used like this:
```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/hchasestevens/bellybutton
    rev: '9653582' # git rev (commit hash in this case)
    hooks:
      - id: bellybutton
```