### PR TITLE
Introduce FileManager and open files as-needed

### DIFF
--- a/.bellybutton.yml
+++ b/.bellybutton.yml
@@ -27,6 +27,13 @@ settings:
       - ~+/tests/*
       - ~+/.tox/*
       - ~+/bellybutton/cli.py
+  excluding_cli_caching: &excluding_cli_caching !settings
+    <<: *excluding_tests
+    excluded:
+      - ~+/tests/*
+      - ~+/.tox/*
+      - ~+/bellybutton/cli.py
+      - ~+/bellybutton/caching.py
 
 default_settings: *excluding_tests
 
@@ -39,9 +46,9 @@ rules:
     settings: *excluding_cli
 
   IllicitOpen:
-    description: Performing I/O outside the CLI module is disallowed.
+    description: Performing I/O outside the CLI or cache module is disallowed.
     expr: //Call[func/Name/@id='open']
     example: |
       with open('x') as f:
         pass
-    settings: *excluding_cli
+    settings: *excluding_cli_caching

--- a/bellybutton/caching.py
+++ b/bellybutton/caching.py
@@ -1,1 +1,17 @@
 """Caching utilities."""
+
+class FileManager:
+    """
+    Load file contents into memory as-needed.
+    """
+    def __init__(self):
+        self.file_contents = dict()
+
+    def get(self, path):
+        try:
+            return self.file_contents[path]
+        except KeyError:
+            with open(path, 'r') as f:
+                contents = f.read()
+            self.file_contents[path] = contents
+            return self.file_contents[path]

--- a/bellybutton/cli.py
+++ b/bellybutton/cli.py
@@ -9,6 +9,7 @@ import subprocess
 from collections import namedtuple
 from textwrap import dedent
 
+from bellybutton.caching import FileManager
 from bellybutton.exceptions import InvalidNode
 from bellybutton.linting import lint_file
 from bellybutton.parsing import load_config
@@ -131,9 +132,11 @@ def get_git_modified(project_directory):
 def linting_failures(filepaths, rules):
     """Given a set of filepaths and a set of rules, yield all rule violations."""
     failures = 0
-    files = open_python_files(filepaths)
-    for filepath, file_contents in files:
-        linting_results = list(lint_file(filepath, file_contents, rules))
+
+    file_manager = FileManager()
+
+    for filepath in filepaths:
+        linting_results = list(lint_file(filepath, file_manager, rules))
         if not linting_results:
             continue
         failure_results = (
@@ -141,6 +144,7 @@ def linting_failures(filepaths, rules):
             for result in linting_results
             if not result.succeeded
         )
+        file_contents = file_manager.get(filepath)
         for failure in failure_results:
             failures += 1
             lines = file_contents.splitlines()

--- a/bellybutton/linting.py
+++ b/bellybutton/linting.py
@@ -42,7 +42,7 @@ def rule_settings_match(rule, filepath):
     return should_be_included and not should_be_excluded
 
 
-def lint_file(filepath, file_contents, rules):
+def lint_file(filepath, file_manager, rules):
     """Run rules against file, yielding any failures."""
     matching_rules = [
         rule
@@ -52,6 +52,7 @@ def lint_file(filepath, file_contents, rules):
     if not matching_rules:
         return
 
+    file_contents = file_manager.get(filepath)
     ignored_lines = get_ignored_lines(file_contents)
     xml_ast = file_contents_to_xml_ast(file_contents)  # todo - use caching module?
 


### PR DESCRIPTION
In this PR, we introduce a simple FileManager class that allows you to open a file as-needed, and caches the contents for future use.

Reasoning: opening all Python files indiscriminately slows us down and is an unnecessary risk.

Longer explanation:

Big repositories have a lot of Python files, many of which might not be covered by the include patterns. It makes no sense to open all these files up front. In the company I work for, bellybutton would actually crash on some test files that contain invalid UTF-8 sequences (by design). These files are not covered by any bellybutton rule, but still crashed it. With this PR, we only open the files when the linter has decided to apply a rule to it.