### PR TITLE
Allow PyYaml > 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     install_requires=[
         'astpath[xpath]==0.6.1',
-        'pyyaml>=4.0,<6.0',
+        'pyyaml>=4.0,<7.0',
         'lxml>=4.1.1',
     ],
     tests_require=['pytest>=3.1.2', 'future>=0.16.0'],


### PR DESCRIPTION
It is not possible to install PyYaml 5.4.1 in Python3.10 Docker container. `pip install PyYaml==5.4.1` fails with horrible error